### PR TITLE
Enable Github Actions for Henshin repository

### DIFF
--- a/otterdog/eclipse-henshin.jsonnet
+++ b/otterdog/eclipse-henshin.jsonnet
@@ -25,7 +25,8 @@ orgs.newOrg('modeling.emft.henshin', 'eclipse-henshin') {
       ],
       web_commit_signoff_required: false,
       workflows+: {
-        enabled: false,
+        enabled: true,
+        default_workflow_permissions: "write",
       },
     },
   ],


### PR DESCRIPTION
and set the default workflow permission to write.

Required for:
- https://github.com/eclipse-henshin/henshin/pull/8

@fredg02 can you please have a look at it?

@dstrueber FYI