### PR TITLE
Enable Update button for PRs in Henshin

### DIFF
--- a/otterdog/eclipse-henshin.jsonnet
+++ b/otterdog/eclipse-henshin.jsonnet
@@ -12,7 +12,6 @@ orgs.newOrg('modeling.emft.henshin', 'eclipse-henshin') {
   _repositories+:: [
     orgs.newRepo('henshin') {
       allow_merge_commit: true,
-      allow_update_branch: false,
       default_branch: "master",
       delete_branch_on_merge: false,
       description: "Henshin is a state of the art model transformation language for the Eclipse Modeling Framework. Henshin supports both direct transformations of EMF single model instances (endogenous transformations), and translation of source model instances into a target language (exogenous transformations).",


### PR DESCRIPTION
The default value of 'allow_update_branch' is true.

This is convenient to update the commit of a PR to the tip of the master/main branch if that has progressed in the meantime.

![grafik](https://github.com/user-attachments/assets/91e599fd-76de-400d-91e6-c5a94c7b040c)


@dstrueber would you be fine with it